### PR TITLE
Removing remote_db env var from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,6 @@ ips ||= YAML.load_file(ips_file)
 passwords ||= YAML.load_file(passwd_file)
 crt_domains ||= YAML.load_file(certificate_domains_file)
 
-node.data['remote_db'] = ENV['REMOTE_DB'] || nil
 $nodes.each do |node|
   node.data['peers'] = ips
   node.data['passwd'] = passwords


### PR DESCRIPTION
The env variable remote_db are not working.
Fix just the Rakefile. It must review the code to improve the implementation.