### PR TITLE
Create portal homologa role 

### DIFF
--- a/config/roles/portal_homologa_server.rb
+++ b/config/roles/portal_homologa_server.rb
@@ -1,0 +1,8 @@
+name "portal_homologa_server"
+description "Install and configure Portal Homologa Server"
+
+run_list *[
+  'recipe[postgresql::service]',
+  'recipe[portal::database]',
+  'recipe[portal::noosfero]',
+]

--- a/nodes.yaml
+++ b/nodes.yaml
@@ -33,7 +33,7 @@ repos:
 
 portalhomologa:
   run_list:
-    - role[portal_server]
+    - role[portal_homologa_server]
 
 codeschool:
   run_list:


### PR DESCRIPTION
Create a different role for 'Portal Homologa', once it was using the same role defined for 'Portal', running then, scripts that are not necessary for homologation machine.