### PR TITLE
urls with www redirect to https upstream server

### DIFF
--- a/cookbooks/letsencrypt/templates/default/default_server_conf.erb
+++ b/cookbooks/letsencrypt/templates/default/default_server_conf.erb
@@ -1,7 +1,4 @@
 server {
-	listen 80;
-	listen [::]:80;
-
   listen 443 ssl;
   listen [::]:443 ssl;
 

--- a/cookbooks/letsencrypt/templates/default/server_conf.erb
+++ b/cookbooks/letsencrypt/templates/default/server_conf.erb
@@ -13,6 +13,20 @@ server {
   }
 }
 
+server {
+  listen [::]:80;
+  listen 80;
+  server_name www.<%= @server_name %> <%= @server_name %>;
+  return 301 https://<%= @server_name %>$request_uri;
+}
+
+server {
+  listen [::]:443;
+  listen 443;
+  server_name www.<%= @server_name %>;
+  return 301 https://<%= @server_name %>$request_uri;
+}
+
 upstream <%= @server %> {
     server <%= @server_ip %>:<%= @service_port %>;
 }


### PR DESCRIPTION
Many subdomains were redirecting wrong URLs with www and http: // subdomain. This pull request corrects this behavior for the following typed URLS:

* http://www.subdomain.lappis.rocks
* http://subdomain.lappis.rocks
* https://www.subdomain.lappis.rocks
* https://subdomain.lappis.rocks

closes #67 